### PR TITLE
Add indent of each lang

### DIFF
--- a/vim/indent.vim
+++ b/vim/indent.vim
@@ -19,14 +19,17 @@ if has("autocmd")
   autocmd FileType c           setlocal sw=4 sts=4 ts=4 et
   autocmd FileType html        setlocal sw=4 sts=4 ts=4 et
   autocmd FileType ruby        setlocal sw=2 sts=2 ts=2 et
+  autocmd FileType php         setlocal sw=2 sts=2 ts=2 et
   autocmd FileType js          setlocal sw=4 sts=4 ts=4 et
   autocmd FileType zsh         setlocal sw=4 sts=4 ts=4 et
   autocmd FileType python      setlocal sw=4 sts=4 ts=4 et
+  autocmd FileType java        setlocal sw=2 sts=2 ts=2 et
   autocmd FileType scala       setlocal sw=4 sts=4 ts=4 et
   autocmd FileType json        setlocal sw=4 sts=4 ts=4 et
-  autocmd FileType html        setlocal sw=4 sts=4 ts=4 et
   autocmd FileType css         setlocal sw=4 sts=4 ts=4 et
   autocmd FileType scss        setlocal sw=4 sts=4 ts=4 et
   autocmd FileType sass        setlocal sw=4 sts=4 ts=4 et
   autocmd FileType javascript  setlocal sw=4 sts=4 ts=4 et
+  autocmd FileType coffee      setlocal sw=2 sts=2 ts=2 et
+  autocmd FileType javascript.jsx  setlocal sw=4 sts=4 ts=4 et
 endif


### PR DESCRIPTION
## WHY
使用言語が増えたため、それぞれのベスト・プラクティスにあったindent を作成

## WHAT
`echo &filetype` からvimの仕様に沿って言語ごとに追加
