### PR TITLE
Add syntax of html5

### DIFF
--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -1,0 +1,15 @@
+"=== html5"
+syn keyword htmlTagName contained article aside audio bb canvas command
+syn keyword htmlTagName contained datalist details dialog embed figure
+syn keyword htmlTagName contained header hgroup keygen mark meter nav output
+syn keyword htmlTagName contained progress time ruby rt rp section time
+syn keyword htmlTagName contained source figcaption
+syn keyword htmlArg contained autofocus autocomplete placeholder min max
+syn keyword htmlArg contained contenteditable contextmenu draggable hidden
+syn keyword htmlArg contained itemprop list sandbox subject spellcheck
+syn keyword htmlArg contained novalidate seamless pattern formtarget
+syn keyword htmlArg contained formaction formenctype formmethod
+syn keyword htmlArg contained sizes scoped async reversed sandbox srcdoc
+syn keyword htmlArg contained hidden role
+syn match   htmlArg "\<\(aria-[\-a-zA-Z0-9_]\+\)=" contained
+syn match   htmlArg contained "\s*data-[-a-zA-Z0-9_]\+"

--- a/vimrc
+++ b/vimrc
@@ -1,17 +1,6 @@
-""----------------------------------------------------------------------------------------------
-"                                        _
-"                                 _   __(_)___ ___  __________
-"                                | | / / / __ `__ \/ ___/ ___/
-"                                | |/ / / / / / / / /  / /__
-"                                |___/_/_/ /_/ /_/_/   \___/
-"
-"                                 thub.com/locona/dotfiles
-"
-"----------------------------------------------------------------------------------------------
-
-"=== Loading
 source ~/.vim/.vimrc.basic
 source ~/.vim/.vimrc.bundle
 source ~/.vim/.vimrc.color
 source ~/.vim/.vimrc.bundle.config
 source ~/.vim/.vimrc.keybind
+source ~/.vim/.vimrc.syntax


### PR DESCRIPTION
## WHY
html5用のタグなどのsyntaxが適用されていない

## WHAT
忘れてしまったが、どこかのサイトを参考にして書いた気がする

- 調べるとplugin が発行されているので、こちらを使用したほうがメンテせずに済むためいいかもしれない
https://github.com/othree/html5.vim

